### PR TITLE
refactor: fix linter errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "bitcoinjs-lib": "^3.3.2",
     "cids": "~0.5.2",
+    "dirty-chai": "^2.0.1",
     "hash.js": "^1.1.3",
     "multihashes": "~0.4.12"
   },

--- a/src/util.js
+++ b/src/util.js
@@ -3,7 +3,7 @@
 const BitcoinjsBlock = require('bitcoinjs-lib').Block
 const CID = require('cids')
 const multihashes = require('multihashes')
-const sha256 = require('hash.js/lib/hash/sha/256');
+const sha256 = require('hash.js/lib/hash/sha/256')
 
 const serialize = (dagNode, callback) => {
   const binaryBlob = dagNode.toBuffer()
@@ -25,7 +25,7 @@ const cid = (dagNode, callback) => {
   const multihash = multihashes.encode(Buffer.from(headerHash), 'dbl-sha2-256')
   const cidVersion = 1
   const cid = new CID(cidVersion, 'bitcoin-block', multihash)
-  const err = null;
+  const err = null
   callback(err, cid)
 }
 

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -2,7 +2,10 @@
 'use strict'
 
 const loadFixture = require('aegir/fixtures')
-const expect = require('chai').expect
+const chai = require('chai')
+const dirtyChai = require('dirty-chai')
+const expect = chai.expect
+chai.use(dirtyChai)
 const IpldBitcoin = require('../src/index')
 
 describe('IPLD format util API', () => {
@@ -11,24 +14,25 @@ describe('IPLD format util API', () => {
 
   it('should deserialize correctly', (done) => {
     IpldBitcoin.util.deserialize(fixtureBlock, (err, dagNode) => {
-      expect(err).to.not.exist
-      expect(dagNode.version).to.equal(2);
+      expect(err).to.not.exist()
+      expect(dagNode.version).to.equal(2)
       expect(dagNode.prevHash.toString('hex')).to.equal(
         '87d6242b27d248a9e145fe764a0bcef03a403883a2e4c8590200000000000000')
       expect(dagNode.merkleRoot.toString('hex')).to.equal(
         '11a5b9a70acebedbbf71ef8ca341e8a98cf279c49eee8f92e10a2227743b6aeb')
-      expect(dagNode.timestamp).to.equal(1386981279);
-      expect(dagNode.bits).to.equal(419740270);
-      expect(dagNode.nonce).to.equal(3159344128);
+      expect(dagNode.timestamp).to.equal(1386981279)
+      expect(dagNode.bits).to.equal(419740270)
+      expect(dagNode.nonce).to.equal(3159344128)
       done()
     })
   })
 
   it('should round-trip (de)serialization correctly', (done) => {
     IpldBitcoin.util.deserialize(fixtureBlock, (err, dagNode) => {
+      expect(err).to.not.exist()
       IpldBitcoin.util.serialize(dagNode, (err, binaryBlob) => {
-        expect(err).to.not.exist
-        expect(binaryBlob.equals(fixtureBlock)).to.be.true
+        expect(err).to.not.exist()
+        expect(binaryBlob.equals(fixtureBlock)).to.be.true()
         done()
       })
     })
@@ -36,8 +40,9 @@ describe('IPLD format util API', () => {
 
   it('should encode the CID correctly', (done) => {
     IpldBitcoin.util.deserialize(fixtureBlock, (err, dagNode) => {
+      expect(err).to.not.exist()
       IpldBitcoin.util.cid(dagNode, (err, cid) => {
-        expect(err).to.not.exist
+        expect(err).to.not.exist()
         expect(cid.multihash.toString('hex')).to.equal(
           '56203ec2c691d447b2fd0d6a94742345af1f351037dab1ab9e900200000000000000')
         done()


### PR DESCRIPTION
In order to fix all errors the "dirty-chai" module is needed.