### PR TITLE
fix: the option in tree() is called `values`

### DIFF
--- a/src/resolver.js
+++ b/src/resolver.js
@@ -64,7 +64,7 @@ const tree = (binaryBlob, options, callback) => {
     const paths = ['/version', '/timestamp', '/difficulty', '/nonce',
       '/parent', '/tx']
 
-    if (options.value === true) {
+    if (options.values === true) {
       const pathValues = {}
       for (let path of paths) {
         pathValues[path] = resolveField(dagNode, path.substr(1))

--- a/test/resolver.spec.js
+++ b/test/resolver.spec.js
@@ -101,7 +101,7 @@ describe('IPLD format resolver API tree()', () => {
   })
 
   it('should be able to return paths and values', (done) => {
-    IpldBitcoin.resolver.tree(fixtureBlock, {value: true}, (err, value) => {
+    IpldBitcoin.resolver.tree(fixtureBlock, {values: true}, (err, value) => {
       expect(err).to.not.exist()
       expect(value).to.deep.equal({
         '/version': 2,


### PR DESCRIPTION
There was a type in the code, where the options object had a
field called `value` instead of `values`.