### PR TITLE
fix: export `multicodec` property

### DIFF
--- a/src/resolver.js
+++ b/src/resolver.js
@@ -134,6 +134,7 @@ const resolveField = (dagNode, field) => {
 }
 
 module.exports = {
+  multicodec: 'bitcoin-block',
   resolve: resolve,
   tree: tree
 }

--- a/test/resolver.spec.js
+++ b/test/resolver.spec.js
@@ -130,6 +130,13 @@ describe('IPLD format resolver API tree()', () => {
   })
 })
 
+describe('IPLD format resolver API properties', () => {
+  it('should have `multicodec` defined correctly', (done) => {
+    expect(IpldBitcoin.resolver.multicodec).to.equal('bitcoin-block')
+    done()
+  })
+})
+
 const verifyPath = (block, path, expected, done) => {
   IpldBitcoin.resolver.resolve(block, path, (err, value) => {
     expect(err).to.not.exist()


### PR DESCRIPTION
The public `multicodec` property is needed to make it work with js-ipld.