### PR TITLE
chore: upgrade Aegir to 12.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "multihashes": "~0.4.12"
   },
   "devDependencies": {
-    "aegir": "^12.1.3",
+    "aegir": "^12.4.0",
     "chai": "^4.1.2"
   },
   "contributors": [


### PR DESCRIPTION
Upgrading Aegir so that the pre-push validation is actually
working.