### PR TITLE
fix: move dirty-chai to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,13 +35,13 @@
   "dependencies": {
     "bitcoinjs-lib": "^3.3.2",
     "cids": "~0.5.2",
-    "dirty-chai": "^2.0.1",
     "hash.js": "^1.1.3",
     "multihashes": "~0.4.12"
   },
   "devDependencies": {
     "aegir": "^13.0.0",
-    "chai": "^4.1.2"
+    "chai": "^4.1.2",
+    "dirty-chai": "^2.0.1"
   },
   "contributors": [
     "David Dias <daviddias.p@gmail.com>",


### PR DESCRIPTION
dirty-chai got installed unnecessarily in production which caused
consumers to get a chai peer dependency warning.