### PR TITLE
fix: operate on block header only

### DIFF
--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,0 +1,12 @@
+'use strict'
+
+const BITCOIN_BLOCK_HEADER_SIZE = require('../src/index')
+  .util.BITCOIN_BLOCK_HEADER_SIZE
+
+const headerFromHexBlock = (hex) => {
+  return Buffer.from(hex.toString(), 'hex').slice(0, BITCOIN_BLOCK_HEADER_SIZE)
+}
+
+module.exports = {
+  headerFromHexBlock
+}

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -7,14 +7,15 @@ const dirtyChai = require('dirty-chai')
 const expect = chai.expect
 chai.use(dirtyChai)
 const IpldBitcoin = require('../src/index')
+const helpers = require('./helpers')
 
 const fixtureBlockHex = loadFixture('test/fixtures/block.hex')
-const fixtureBlock = Buffer.from(fixtureBlockHex.toString(), 'hex')
+const fixtureBlockHeader = helpers.headerFromHexBlock(fixtureBlockHex)
 const invalidDagNode = {invalid: 'dagNode'}
 
 describe('IPLD format util API deserialize()', () => {
   it('should work correctly', (done) => {
-    IpldBitcoin.util.deserialize(fixtureBlock, (err, dagNode) => {
+    IpldBitcoin.util.deserialize(fixtureBlockHeader, (err, dagNode) => {
       expect(err).to.not.exist()
       verifyBlock(dagNode, {
         version: 2,
@@ -30,8 +31,8 @@ describe('IPLD format util API deserialize()', () => {
 
   it('should deserialize Segwit correctly (a)', (done) => {
     const segwitBlockHex = loadFixture('test/fixtures/segwit.hex')
-    const segwitBlock = Buffer.from(segwitBlockHex.toString(), 'hex')
-    IpldBitcoin.util.deserialize(segwitBlock, (err, dagNode) => {
+    const segwitBlockHeader = helpers.headerFromHexBlock(segwitBlockHex)
+    IpldBitcoin.util.deserialize(segwitBlockHeader, (err, dagNode) => {
       expect(err).to.not.exist()
       verifyBlock(dagNode, {
         version: 536870914,
@@ -50,8 +51,8 @@ describe('IPLD format util API deserialize()', () => {
 
   it('should deserialize Segwit correctly (b)', (done) => {
     const segwitBlockHex = loadFixture('test/fixtures/segwit2.hex')
-    const segwitBlock = Buffer.from(segwitBlockHex.toString(), 'hex')
-    IpldBitcoin.util.deserialize(segwitBlock, (err, dagNode) => {
+    const segwitBlockHeader = helpers.headerFromHexBlock(segwitBlockHex)
+    IpldBitcoin.util.deserialize(segwitBlockHeader, (err, dagNode) => {
       expect(err).to.not.exist()
       verifyBlock(dagNode, {
         version: 536870914,
@@ -70,8 +71,8 @@ describe('IPLD format util API deserialize()', () => {
 
   it('should deserialize Segwit correctly (c)', (done) => {
     const segwitBlockHex = loadFixture('test/fixtures/segwit3.hex')
-    const segwitBlock = Buffer.from(segwitBlockHex.toString(), 'hex')
-    IpldBitcoin.util.deserialize(segwitBlock, (err, dagNode) => {
+    const segwitBlockHeader = helpers.headerFromHexBlock(segwitBlockHex)
+    IpldBitcoin.util.deserialize(segwitBlockHeader, (err, dagNode) => {
       expect(err).to.not.exist()
       verifyBlock(dagNode, {
         version: 536870912,
@@ -88,19 +89,6 @@ describe('IPLD format util API deserialize()', () => {
     })
   })
 
-  it('should deserialize a block without transactions', (done) => {
-    const hexData = '01000000000102e9b542c5176808107ff1df906f46bb1f2583b16112b95ee5380665ba7fcfc0010000000000ffffffff80e68831516392fcd100d186b3c2c7b95c80b53c77e77c35ba03a66b429a2a1b0000000000ffffffff0280969800000000001976a914de4b231626ef508c9a74a8517e6783c0546d6b2888ac80969800000000001976a9146648a8cd4531e1ec47f35916de8e259237294d1e88ac02483045022100f6a10b8604e6dc910194b79ccfc93e1bc0ec7c03453caaa8987f7d6c3413566002206216229ede9b4d6ec2d325be245c5b508ff0339bf1794078e20bfe0babc7ffe683270063ab68210392972e2eb617b2388771abe27235fd5ac44af8e61693261550447a4c3e39da98ac024730440220032521802a76ad7bf74d0e2c218b72cf0cbc867066e2e53db905ba37f130397e02207709e2188ed7f08f4c952d9d1398'
-    const block = Buffer.from(hexData.toString(), 'hex')
-    IpldBitcoin.util.deserialize(block, (err, dagNode) => {
-      expect(err).to.not.exist()
-      expect(dagNode.transactions).to.be.empty()
-      verifyCid(
-        dagNode,
-        '56200cf2049d7ce53bebaa4e8105606ee4663ca6d8e73a84fa40717133137cfc32b8',
-        done)
-    })
-  })
-
   it('should error on an invalid block', (done) => {
     const invalidBlock = Buffer.from('abcdef', 'hex')
     IpldBitcoin.util.deserialize(invalidBlock, (err, dagNode) => {
@@ -113,11 +101,11 @@ describe('IPLD format util API deserialize()', () => {
 
 describe('IPLD format util API serialize()', () => {
   it('should round-trip (de)serialization correctly', (done) => {
-    IpldBitcoin.util.deserialize(fixtureBlock, (err, dagNode) => {
+    IpldBitcoin.util.deserialize(fixtureBlockHeader, (err, dagNode) => {
       expect(err).to.not.exist()
       IpldBitcoin.util.serialize(dagNode, (err, binaryBlob) => {
         expect(err).to.not.exist()
-        expect(binaryBlob).to.deep.equal(fixtureBlock)
+        expect(binaryBlob).to.deep.equal(fixtureBlockHeader)
         done()
       })
     })
@@ -134,7 +122,7 @@ describe('IPLD format util API serialize()', () => {
 
 describe('IPLD format util API cid()', () => {
   it('should encode the CID correctly', (done) => {
-    IpldBitcoin.util.deserialize(fixtureBlock, (err, dagNode) => {
+    IpldBitcoin.util.deserialize(fixtureBlockHeader, (err, dagNode) => {
       expect(err).to.not.exist()
       verifyCid(
         dagNode,
@@ -152,7 +140,7 @@ describe('IPLD format util API cid()', () => {
   })
 
   it('should encode the CID correctly with options', (done) => {
-    IpldBitcoin.util.deserialize(fixtureBlock, (err, dagNode) => {
+    IpldBitcoin.util.deserialize(fixtureBlockHeader, (err, dagNode) => {
       expect(err).to.not.exist()
       verifyCid1(
         dagNode,
@@ -163,7 +151,7 @@ describe('IPLD format util API cid()', () => {
   })
 
   it('should encode the CID correctly with undefined options', (done) => {
-    IpldBitcoin.util.deserialize(fixtureBlock, (err, dagNode) => {
+    IpldBitcoin.util.deserialize(fixtureBlockHeader, (err, dagNode) => {
       expect(err).to.not.exist()
       verifyCid1(
         dagNode,
@@ -174,7 +162,7 @@ describe('IPLD format util API cid()', () => {
   })
 
   it('should encode the CID correctly with default options specified', (done) => {
-    IpldBitcoin.util.deserialize(fixtureBlock, (err, dagNode) => {
+    IpldBitcoin.util.deserialize(fixtureBlockHeader, (err, dagNode) => {
       expect(err).to.not.exist()
       verifyCid1(
         dagNode,


### PR DESCRIPTION
The current implementation was wrong. You were able to add a full
block (including transactions), but the CID was only calculated
based on the header.

The correct implementation is to work on the block header only.

Transaction support needs to be implemented separately.