### PR TITLE
Remove git-validate as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "async": "^2.6.1",
     "bitcoinjs-lib": "^4.0.2",
     "cids": "~0.5.2",
-    "git-validate": "^2.2.2",
     "multihashes": "~0.4.12",
     "multihashing-async": "~0.5.1"
   },


### PR DESCRIPTION
The `git-validate` package should not be a dependency, as this causes it to be included when this package is installed. Depending on the order in which packages are installed, this may overwrite other git hooks unexpectedly.

It was also noted by @vmx that it's no longer necessary to explicitly put this in `devDependencies` as it's included with `aegir`.