### PR TITLE
docs: add better contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+# Contributing guidelines
+
+We adhere to the [Guidelines for the InterPlanetary JavaScript Projects](https://github.com/ipfs/community/blob/master/CONTRIBUTING_JS.md) which provide additional information of how to collaborate and contribute in the JavaScript implementation of IPLD.
+
+Check out our [contributing document](https://github.com/ipld/ipld/blob/master/contributing.md) for more information on how we work, and about contributing in general. Please be aware that all interactions related to IPLD are subject to the IPFS [Code of Conduct](https://github.com/ipfs/community/blob/master/code-of-conduct.md).
+
+Thank you.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ IpldBitcoin.util.deserialize(bitcoinBlock, (err, dagNode) => {
 
 Feel free to join in. All welcome. Open an [issue](https://github.com/ipld/js-ipld-bitcoin/issues)!
 
-Check out our [contributing document](https://github.com/ipld/ipld/blob/master/contributing.md) for more information on how we work, and about contributing in general. Please be aware that all interactions related to IPLD are subject to the IPFS [Code of Conduct](https://github.com/ipfs/community/blob/master/code-of-conduct.md).
+For more information please check out the [contributing guidelines](CONTRIBUTING.md).
 
 Small note: If editing the README, please conform to the [standard-readme](https://github.com/RichardLitt/standard-readme) specification.
 


### PR DESCRIPTION
Have a link to the [Guidelines for the InterPlanetary JavaScript
Projects]. It is in a file called `CONTRIBUTING.md` so the GitHub
will automatically pick it up and display for first time contributors.

The `CONTRIBUTING.md` is intentionally without any repository specific
information so that it can be re-used on other repos as well.

[Guidelines for the InterPlanetary JavaScript Projects]: https://github.com/ipfs/community/blob/master/CONTRIBUTING_JS.md