### PR TITLE
chore: update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,13 +35,13 @@
   "dependencies": {
     "async": "^2.6.1",
     "bitcoinjs-lib": "^4.0.2",
-    "cids": "~0.5.2",
-    "multihashes": "~0.4.12",
+    "cids": "~0.5.6",
+    "multihashes": "~0.4.14",
     "multihashing-async": "~0.5.1"
   },
   "devDependencies": {
-    "aegir": "^17.1.0",
-    "chai": "^4.1.2",
+    "aegir": "^17.1.1",
+    "chai": "^4.2.0",
     "dirty-chai": "^2.0.1"
   },
   "contributors": [

--- a/src/resolver.js
+++ b/src/resolver.js
@@ -123,9 +123,9 @@ const resolveField = (dagNode, field) => {
     case 'nonce':
       return dagNode.nonce
     case 'parent':
-      return {'/': util.hashToCid(dagNode.prevHash)}
+      return { '/': util.hashToCid(dagNode.prevHash) }
     case 'tx':
-      return {'/': util.hashToCid(dagNode.merkleRoot)}
+      return { '/': util.hashToCid(dagNode.merkleRoot) }
     default:
       return null
   }

--- a/test/resolver.spec.js
+++ b/test/resolver.spec.js
@@ -66,7 +66,8 @@ describe('IPLD format resolve API resolve()', () => {
       expect(err).to.not.exist()
       expect(value.remainderPath).is.empty()
       expect(value.value).to.deep.equal({
-        '/': new CID('z4HFzdHLxSgJvCMJrsDtV7MgqiGALZdbbxgcTLVUUXQGBkGYjLb')})
+        '/': new CID('z4HFzdHLxSgJvCMJrsDtV7MgqiGALZdbbxgcTLVUUXQGBkGYjLb')
+      })
       done()
     })
   })
@@ -79,7 +80,8 @@ describe('IPLD format resolve API resolve()', () => {
           expect(value.remainderPath).to.equal('timestamp')
           expect(value.value).to.deep.equal({
             '/':
-              new CID('z4HFzdHLxSgJvCMJrsDtV7MgqiGALZdbbxgcTLVUUXQGBkGYjLb')})
+              new CID('z4HFzdHLxSgJvCMJrsDtV7MgqiGALZdbbxgcTLVUUXQGBkGYjLb')
+          })
           done()
         })
     })
@@ -90,7 +92,8 @@ describe('IPLD format resolve API resolve()', () => {
         expect(err).to.not.exist()
         expect(value.remainderPath).to.equal('some/remainder')
         expect(value.value).to.deep.equal({
-          '/': new CID('z4HFzdHD15kVvtmVzeD7z9sisZ7acSC88wXS3KJGwGrnr2DwcVQ')})
+          '/': new CID('z4HFzdHD15kVvtmVzeD7z9sisZ7acSC88wXS3KJGwGrnr2DwcVQ')
+        })
         done()
       })
   })
@@ -111,7 +114,7 @@ describe('IPLD format resolver API tree()', () => {
   })
 
   it('should be able to return paths and values', (done) => {
-    IpldBitcoin.resolver.tree(fixtureBlockHeader, {values: true}, (err, value) => {
+    IpldBitcoin.resolver.tree(fixtureBlockHeader, { values: true }, (err, value) => {
       expect(err).to.not.exist()
       expect(value).to.deep.equal({
         version: 2,
@@ -119,9 +122,12 @@ describe('IPLD format resolver API tree()', () => {
         difficulty: 419740270,
         nonce: 3159344128,
         parent: {
-          '/': new CID('z4HFzdHLxSgJvCMJrsDtV7MgqiGALZdbbxgcTLVUUXQGBkGYjLb')},
+          '/': new CID('z4HFzdHLxSgJvCMJrsDtV7MgqiGALZdbbxgcTLVUUXQGBkGYjLb')
+        },
         tx: {
-          '/': new CID('z4HFzdHD15kVvtmVzeD7z9sisZ7acSC88wXS3KJGwGrnr2DwcVQ')}})
+          '/': new CID('z4HFzdHD15kVvtmVzeD7z9sisZ7acSC88wXS3KJGwGrnr2DwcVQ')
+        }
+      })
       done()
     })
   })

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -11,7 +11,7 @@ const helpers = require('./helpers')
 
 const fixtureBlockHex = loadFixture('test/fixtures/block.hex')
 const fixtureBlockHeader = helpers.headerFromHexBlock(fixtureBlockHex)
-const invalidDagNode = {invalid: 'dagNode'}
+const invalidDagNode = { invalid: 'dagNode' }
 
 describe('IPLD format util API deserialize()', () => {
   it('should work correctly', (done) => {


### PR DESCRIPTION
Due to aegir 17.1.1 upgrading the standard-js module code changes
are needed in order to make lint pass.