### PR TITLE
refactor: default to CID v1 and encode with base32

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "async": "^2.6.1",
     "bitcoinjs-lib": "^4.0.2",
-    "cids": "~0.5.6",
+    "cids": "github:multiformats/js-cid#refactor/cidv1base32-default",
     "multihashes": "~0.4.14",
     "multihashing-async": "~0.5.1"
   },


### PR DESCRIPTION
BREAKING CHANGE: Any CIDs this module returns are base32 encoded by default when stringified.

Depends on:

* [ ] https://github.com/multiformats/js-cid/pull/73