### PR TITLE
fix: replace node buffers with uint8array

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,15 +35,14 @@
   "dependencies": {
     "bitcoinjs-lib": "^5.0.0",
     "buffer": "^5.6.0",
-    "cids": "^0.8.3",
-    "multicodec": "^1.0.0",
-    "multihashes": "^1.0.1",
-    "multihashing-async": "^1.0.0"
+    "cids": "^1.0.0",
+    "multicodec": "^2.0.0",
+    "multihashes": "^3.0.0",
+    "multihashing-async": "^2.0.0",
+    "uint8arrays": "^1.0.0"
   },
   "devDependencies": {
-    "aegir": "^25.0.0",
-    "chai": "^4.2.0",
-    "dirty-chai": "^2.0.1"
+    "aegir": "^25.0.0"
   },
   "contributors": [
     "Volker Mische <volker.mische@gmail.com>",

--- a/src/resolver.js
+++ b/src/resolver.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const CID = require('cids')
-const { Buffer } = require('buffer')
 
 const util = require('./util')
 
@@ -11,7 +10,7 @@ const util = require('./util')
  * Returns the value or a link and the partial mising path. This way the
  * IPLD Resolver can fetch the link and continue to resolve.
  *
- * @param {Buffer} binaryBlob - Binary representation of a Bitcoin block
+ * @param {Uint8Array} binaryBlob - Binary representation of a Bitcoin block
  * @param {string} [path='/'] - Path that should be resolved
  * @returns {Object} result - Result of the path it it was resolved successfully
  * @returns {*} result.value - Value the path resolves to
@@ -46,7 +45,7 @@ exports.resolve = (binaryBlob, path) => {
 
 const traverse = function * (node, path) {
   // Traverse only objects and arrays
-  if (Buffer.isBuffer(node) || CID.isCID(node) || typeof node === 'string' ||
+  if (node instanceof Uint8Array || CID.isCID(node) || typeof node === 'string' ||
       node === null) {
     return
   }
@@ -61,7 +60,7 @@ const traverse = function * (node, path) {
  * Return all available paths of a block.
  *
  * @generator
- * @param {Buffer} binaryBlob - Binary representation of a Bitcoin block
+ * @param {Uint8Array} binaryBlob - Binary representation of a Bitcoin block
  * @yields {string} - A single path
  */
 exports.tree = function * (binaryBlob) {

--- a/src/util.js
+++ b/src/util.js
@@ -18,7 +18,7 @@ const DEFAULT_HASH_ALG = multicodec.DBL_SHA2_256
  * @returns {Uint8Array}
  */
 const serialize = (dagNode) => {
-  return new Uint8Array(dagNode.toBuffer(true))
+  return dagNode.toBuffer(true)
 }
 
 /**

--- a/src/util.js
+++ b/src/util.js
@@ -5,6 +5,7 @@ const CID = require('cids')
 const multicodec = require('multicodec')
 const multihashes = require('multihashes')
 const multihashing = require('multihashing-async')
+const { Buffer } = require('buffer')
 
 const BITCOIN_BLOCK_HEADER_SIZE = 80
 const CODEC = multicodec.BITCOIN_BLOCK
@@ -14,16 +15,16 @@ const DEFAULT_HASH_ALG = multicodec.DBL_SHA2_256
  * Serialize internal representation into a binary Bitcoin block.
  *
  * @param {BitcoinBlock} dagNode - Internal representation of a Bitcoin block
- * @returns {Buffer}
+ * @returns {Uint8Array}
  */
 const serialize = (dagNode) => {
-  return dagNode.toBuffer(true)
+  return new Uint8Array(dagNode.toBuffer(true))
 }
 
 /**
  * Deserialize Bitcoin block into the internal representation.
  *
- * @param {Buffer} binaryBlob - Binary representation of a Bitcoin block
+ * @param {Uint8Array} binaryBlob - Binary representation of a Bitcoin block
  * @returns {BitcoinBlock}
  */
 const deserialize = (binaryBlob) => {
@@ -32,7 +33,7 @@ const deserialize = (binaryBlob) => {
       `Bitcoin block header needs to be ${BITCOIN_BLOCK_HEADER_SIZE} bytes`)
   }
 
-  const deserialized = BitcoinjsBlock.fromBuffer(binaryBlob)
+  const deserialized = BitcoinjsBlock.fromBuffer(Buffer.from(binaryBlob))
 
   const getters = {
     difficulty: function () {
@@ -88,7 +89,7 @@ const cid = async (binaryBlob, userOptions) => {
   return cid
 }
 
-// Convert a Bitcoin hash (as Buffer) to a CID
+// Convert a Bitcoin hash (as Uint8Array) to a CID
 const hashToCid = (hash) => {
   const multihash = multihashes.encode(hash, DEFAULT_HASH_ALG)
   const cidVersion = 1

--- a/src/util.js
+++ b/src/util.js
@@ -33,7 +33,11 @@ const deserialize = (binaryBlob) => {
       `Bitcoin block header needs to be ${BITCOIN_BLOCK_HEADER_SIZE} bytes`)
   }
 
-  const deserialized = BitcoinjsBlock.fromBuffer(Buffer.from(binaryBlob))
+  if (!Buffer.isBuffer(binaryBlob)) {
+    binaryBlob = Buffer.from(binaryBlob)
+  }
+
+  const deserialized = BitcoinjsBlock.fromBuffer(binaryBlob)
 
   const getters = {
     difficulty: function () {

--- a/src/util.js
+++ b/src/util.js
@@ -34,7 +34,7 @@ const deserialize = (binaryBlob) => {
   }
 
   if (!Buffer.isBuffer(binaryBlob)) {
-    binaryBlob = Buffer.from(binaryBlob)
+    binaryBlob = Buffer.from(binaryBlob, binaryBlob.byteOffset, binaryBlob.byteLength)
   }
 
   const deserialized = BitcoinjsBlock.fromBuffer(binaryBlob)

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,12 +1,12 @@
 'use strict'
 
-const { Buffer } = require('buffer')
+const uint8ArrayFromString = require('uint8arrays/from-string')
 
 const BITCOIN_BLOCK_HEADER_SIZE = require('../src/index')
   .util.BITCOIN_BLOCK_HEADER_SIZE
 
 const headerFromHexBlock = (hex) => {
-  return Buffer.from(hex.toString(), 'hex').slice(0, BITCOIN_BLOCK_HEADER_SIZE)
+  return uint8ArrayFromString(hex.toString(), 'base16').slice(0, BITCOIN_BLOCK_HEADER_SIZE)
 }
 
 module.exports = {

--- a/test/mod.spec.js
+++ b/test/mod.spec.js
@@ -1,10 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
+const { expect } = require('aegir/utils/chai')
 const multicodec = require('multicodec')
 
 const mod = require('../src')

--- a/test/resolver.spec.js
+++ b/test/resolver.spec.js
@@ -2,18 +2,15 @@
 'use strict'
 
 const loadFixture = require('aegir/fixtures')
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
+const { expect } = require('aegir/utils/chai')
 const CID = require('cids')
-const { Buffer } = require('buffer')
+const uint8ArrayFromString = require('uint8arrays/from-string')
 const IpldBitcoin = require('../src/index')
 const helpers = require('./helpers')
 
 const fixtureBlockHex = loadFixture('test/fixtures/block.hex')
 const fixtureBlockHeader = helpers.headerFromHexBlock(fixtureBlockHex)
-const invalidBlock = Buffer.from('abcdef', 'hex')
+const invalidBlock = uint8ArrayFromString('abcdef', 'base16')
 
 describe('IPLD format resolve API resolve()', () => {
   it('should return the deserialized node if path is empty', () => {

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -26,6 +26,18 @@ describe('IPLD format util API deserialize()', () => {
     })
   })
 
+  it('should work correctly with Uint8Arrays', () => {
+    const dagNode = IpldBitcoin.util.deserialize(Uint8Array.from(fixtureBlockHeader))
+    verifyBlock(dagNode, {
+      version: 2,
+      prevHash: '87d6242b27d248a9e145fe764a0bcef03a403883a2e4c8590200000000000000',
+      merkleRoot: '11a5b9a70acebedbbf71ef8ca341e8a98cf279c49eee8f92e10a2227743b6aeb',
+      timestamp: 1386981279,
+      bits: 419740270,
+      nonce: 3159344128
+    })
+  })
+
   it('should deserialize Segwit correctly (a)', () => {
     const segwitBlockHex = loadFixture('test/fixtures/segwit.hex')
     const segwitBlockHeader = helpers.headerFromHexBlock(segwitBlockHex)

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -2,13 +2,10 @@
 'use strict'
 
 const loadFixture = require('aegir/fixtures')
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
+const { expect } = require('aegir/utils/chai')
 const CID = require('cids')
 const multicodec = require('multicodec')
-const { Buffer } = require('buffer')
+const uint8ArrayFromString = require('uint8arrays/from-string')
 const IpldBitcoin = require('../src/index')
 const helpers = require('./helpers')
 
@@ -72,7 +69,7 @@ describe('IPLD format util API deserialize()', () => {
   })
 
   it('should error on an invalid block', () => {
-    const invalidBlock = Buffer.from('abcdef', 'hex')
+    const invalidBlock = uint8ArrayFromString('abcdef', 'base16')
     expect(() => {
       IpldBitcoin.util.deserialize(invalidBlock)
     }).to.throw('Bitcoin block header needs to be 80 bytes')
@@ -94,9 +91,9 @@ describe('IPLD format util API serialize()', () => {
 })
 
 describe('IPLD format util API cid()', () => {
-  const expectedCid = new CID(1, 'bitcoin-block', Buffer.from(
+  const expectedCid = new CID(1, 'bitcoin-block', uint8ArrayFromString(
     '56203ec2c691d447b2fd0d6a94742345af1f351037dab1ab9e900200000000000000',
-    'hex'))
+    'base16'))
 
   it('should encode the CID correctly', async () => {
     const cid = await IpldBitcoin.util.cid(fixtureBlockHeader)
@@ -107,9 +104,9 @@ describe('IPLD format util API cid()', () => {
     const cid = await IpldBitcoin.util.cid(fixtureBlockHeader, {
       hashAlg: multicodec.SHA3_256
     })
-    expect(cid.equals(new CID(1, 'bitcoin-block', Buffer.from(
+    expect(cid.equals(new CID(1, 'bitcoin-block', uint8ArrayFromString(
       '16208fd2802e0304c79c08a1ff2afb706ce64b78f3b94fd1c9142946c2e715589cfb',
-      'hex'
+      'base16'
     )))).to.be.true()
   })
 


### PR DESCRIPTION
Accepts and emits `Uint8Array`s instead of node `Buffer`s but converts
them internally because `bitcoinjs-lib` only understands `Buffer`s.

BREAKING CHANGE:

- `util.cid` returns v1 `CID`s