### PR TITLE
fix: remove redundant multihashes dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "buffer": "^5.6.0",
     "cids": "^1.0.0",
     "multicodec": "^2.0.0",
-    "multihashes": "^3.0.0",
     "multihashing-async": "^2.0.0",
     "uint8arrays": "^1.0.0"
   },

--- a/src/util.js
+++ b/src/util.js
@@ -3,8 +3,8 @@
 const BitcoinjsBlock = require('bitcoinjs-lib').Block
 const CID = require('cids')
 const multicodec = require('multicodec')
-const multihashes = require('multihashes')
 const multihashing = require('multihashing-async')
+const multihashes = multihashing.multihash
 const { Buffer } = require('buffer')
 
 const BITCOIN_BLOCK_HEADER_SIZE = 80


### PR DESCRIPTION
The multihashes module is bundled with multihashing-async so no need to depend on it as well.